### PR TITLE
Use tox to run the tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /build
 /.coverage
+/.tox
 /delta.egg-info/
 /dist
 /.eggs

--- a/README.md
+++ b/README.md
@@ -68,3 +68,12 @@ tdelta = delta.parse('2 months', context=datetime(2016, 1, 1))
 The above delta calculated will take into account that the `context` is set to
 the first day of 2016 which means 2 months is 31 days from January and 29 days
 from February.
+
+## tests
+
+Tests can be run using [tox](http://tox.testrun.org).
+
+```
+pip install tox
+tox
+```

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,6 @@
+[tox]
+envlist = py27,pypy
+
+[testenv]
+commands =
+    python setup.py test


### PR DESCRIPTION
tox will make it easier to test delta with multiple versions of Python.