### PR TITLE
Add support for Python 3

### DIFF
--- a/delta/parse.py
+++ b/delta/parse.py
@@ -1,6 +1,8 @@
 """
 deltas parse module
 """
+from __future__ import division
+
 import calendar
 import re
 
@@ -85,7 +87,7 @@ def parse(duration, context=None):
                                         datetime(year + whole, 1, 1)).days + 1
 
                         end += timedelta(days=(fraction * days_in_year))
-                    
+
                     seconds = (end - start).total_seconds()
 
                 elif key == 'months':
@@ -95,14 +97,14 @@ def parse(duration, context=None):
 
                     # figure out how many whole years and left over months and
                     # then let pythons datetime do all the work
-                    years = whole / 12
+                    years = whole // 12
                     months = whole % 12
 
                     end_month = month + months
                     if end_month > 12:
                         # detect month overflow and bump the year and calculate
                         # the right end_month to use
-                        years += end_month / 12
+                        years += end_month // 12
                         end_month = end_month % 12
 
                     start = datetime(year, month, day)
@@ -114,7 +116,7 @@ def parse(duration, context=None):
                     if end_month > 12:
                         # detect month overflow and bump the year and calculate
                         # the right end_month to use
-                        end_year += end_month / 12
+                        end_year += end_month // 12
                         end_month = end_month % 12
 
                     _, end_day = calendar.monthrange(end_year, end_month)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,pypy
+envlist = py27,py34,py35,pypy
 
 [testenv]
 commands =


### PR DESCRIPTION
The integer division operator changed in Python 3 from `/` to `//`. `/`
will perform float division. Python 2 offers this behavior through a
future import. Introducing the import and using the new operator makes
delta work on both Python 2 and 3.